### PR TITLE
Add support for NN, NNpsk0 handshake patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ console.log(initiator.complete) // true
 // responder.rx === initiator.tx
 
 // instantiate a cipher using shared secrets
-const send = new Cipher(initiator.rx)
-const recieve = new Cipher(responder.tx)
+const send = new Cipher(initiator.tx)
+const recieve = new Cipher(responder.rx)
 
 const msg = Buffer.from('hello, world')
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ console.log(recieve.decrypt(enc)) // hello, world
 
 Create a new handshake state for a given pattern. Initiator should be either `true` or `false` depending on the role. A preexisting keypair may be passed as `staticKeypair`
 
-`opts` is may be used to pass in a `curve` module for performing Noise over other curves.
+`opts` may be used to pass in the following:
+- `curve`: module for performing Noise over other curves.
+- `psk`: a 32-byte buffer containing a pre-shared key for patterns containing `psk0`. (Other psk positions are not currently supported.)
 
 Curve modules should export the following:
 ```

--- a/hkdf.js
+++ b/hkdf.js
@@ -13,9 +13,13 @@ function hkdf (salt, inputKeyMaterial, info = '', length = 2 * HASHLEN) {
   const pseudoRandomKey = hkdfExtract(salt, inputKeyMaterial)
   const result = hkdfExpand(pseudoRandomKey, info, length)
 
-  const [k1, k2] = [result.slice(0, HASHLEN), result.slice(HASHLEN)]
-
-  return [k1, k2]
+  const results = []
+  let offset = 0
+  while (offset < result.length) {
+    results.push(result.subarray(offset, offset + HASHLEN))
+    offset += HASHLEN
+  }
+  return results
 
   function hkdfExtract (salt, inputKeyMaterial) {
     return hmacDigest(salt, inputKeyMaterial)

--- a/hkdf.js
+++ b/hkdf.js
@@ -9,6 +9,9 @@ module.exports = {
   HASHLEN
 }
 
+// HMAC-based Extract-and-Expand KDF
+// https://www.ietf.org/rfc/rfc5869.txt
+
 function hkdf (salt, inputKeyMaterial, info = '', length = 2 * HASHLEN) {
   const pseudoRandomKey = hkdfExtract(salt, inputKeyMaterial)
   const result = hkdfExpand(pseudoRandomKey, info, length)

--- a/noise.js
+++ b/noise.js
@@ -115,12 +115,6 @@ module.exports = class NoiseState extends SymmetricState {
     this.rx = null
     this.tx = null
     this.hash = null
-
-    function hasPskToken (handshake) {
-      return handshake.reduce((xs, x) => {
-        return (Array.isArray(x) && x.indexOf(TOK_PSK) !== -1) || xs
-      }, false)
-    }
   }
 
   initialise (prologue, remoteStatic) {
@@ -292,4 +286,10 @@ function keyPattern (pattern, initiator) {
       ret.remote ^= 1
       return ret
   }
+}
+
+function hasPskToken (handshake) {
+  return handshake.some(x => {
+    return Array.isArray(x) && x.indexOf(TOK_PSK) !== -1
+  })
 }

--- a/noise.js
+++ b/noise.js
@@ -31,6 +31,11 @@ const HANDSHAKES = Object.freeze({
     [TOK_E, TOK_EE, TOK_S, TOK_ES],
     [TOK_S, TOK_SE]
   ],
+  XXpsk0: [
+    [TOK_PSK, TOK_E],
+    [TOK_E, TOK_EE, TOK_S, TOK_ES],
+    [TOK_S, TOK_SE]
+  ],
   IK: [
     PRESHARE_RS,
     [TOK_E, TOK_ES, TOK_S, TOK_SS],

--- a/symmetric-state.js
+++ b/symmetric-state.js
@@ -21,6 +21,19 @@ module.exports = class SymmetricState extends CipherState {
     accumulateDigest(this.digest, data)
   }
 
+  mixKeyAndHash (key) {
+    const [ck, tempH, tempK] = hkdf(this.chainingKey, key, '', 3 * HASHLEN)
+    this.chainingKey = ck
+    this.mixHash(tempH)
+    this.initialiseKey(tempK.subarray(0, 32))
+  }
+
+  mixKeyNormal (key) {
+    const [ck, tempK] = hkdf(this.chainingKey, key)
+    this.chainingKey = ck
+    this.initialiseKey(tempK.subarray(0, 32))
+  }
+
   mixKey (remoteKey, localKey) {
     const dh = this.curve.dh(remoteKey, localKey)
     const hkdfResult = hkdf(this.chainingKey, dh)

--- a/test/handshake.js
+++ b/test/handshake.js
@@ -48,3 +48,63 @@ test('XX', t => {
   t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })
+
+test('NN', t => {
+  const initiator = new NoiseState('NN', true, null)
+  const responder = new NoiseState('NN', false, null)
+
+  initiator.initialise(Buffer.alloc(0))
+  responder.initialise(Buffer.alloc(0))
+
+  const message = initiator.send()
+  responder.recv(message)
+
+  const reply = responder.send()
+  initiator.recv(reply)
+
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
+  t.end()
+})
+
+test('NNpsk0: bad', t => {
+  t.plan(1)
+
+  const psk1 = Buffer.from(
+    '324eee92611cd877841c4de9fd5253e9dba6033329a837ee5f01beb005dffb2f', 'hex')
+  const psk2 = Buffer.from(
+    'ebdb9f8cd9c704844ca47b88fe7526a3c9f865be998486ca16ae3431e019d0cc', 'hex')
+  const initiator = new NoiseState('NNpsk0', true, null, { psk: psk1 })
+  const responder = new NoiseState('NNpsk0', false, null, { psk: psk2 })
+
+  initiator.initialise(Buffer.alloc(0))
+  responder.initialise(Buffer.alloc(0))
+
+  const message = initiator.send()
+  try {
+    responder.recv(message)
+    t.fail('should have failed to verify!')
+  } catch (err) {
+    t.equals(err.toString(), 'Error: could not verify data')
+  }
+})
+
+test('NNpsk0: good', t => {
+  const psk = Buffer.from(
+    '324eee92611cd877841c4de9fd5253e9dba6033329a837ee5f01beb005dffb2f', 'hex')
+  const initiator = new NoiseState('NNpsk0', true, null, { psk })
+  const responder = new NoiseState('NNpsk0', false, null, { psk })
+
+  initiator.initialise(Buffer.alloc(0))
+  responder.initialise(Buffer.alloc(0))
+
+  const message = initiator.send()
+  responder.recv(message)
+
+  const reply = responder.send()
+  initiator.recv(reply)
+
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
+  t.end()
+})

--- a/test/handshake.js
+++ b/test/handshake.js
@@ -108,3 +108,45 @@ test('NNpsk0: good', t => {
   t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })
+
+test('XXpsk0: bad', t => {
+  t.plan(1)
+
+  const psk1 = Buffer.from(
+    '324eee92611cd877841c4de9fd5253e9dba6033329a837ee5f01beb005dffb2f', 'hex')
+  const psk2 = Buffer.from(
+    'ebdb9f8cd9c704844ca47b88fe7526a3c9f865be998486ca16ae3431e019d0cc', 'hex')
+  const initiator = new NoiseState('XXpsk0', true, null, { psk: psk1 })
+  const responder = new NoiseState('XXpsk0', false, null, { psk: psk2 })
+
+  initiator.initialise(Buffer.alloc(0))
+  responder.initialise(Buffer.alloc(0))
+
+  const message = initiator.send()
+  try {
+    responder.recv(message)
+    t.fail('should have failed to verify!')
+  } catch (err) {
+    t.equals(err.toString(), 'Error: could not verify data')
+  }
+})
+
+test('XXpsk0: good', t => {
+  const psk = Buffer.from(
+    '324eee92611cd877841c4de9fd5253e9dba6033329a837ee5f01beb005dffb2f', 'hex')
+  const initiator = new NoiseState('XXpsk0', true, null, { psk })
+  const responder = new NoiseState('XXpsk0', false, null, { psk })
+
+  initiator.initialise(Buffer.alloc(0))
+  responder.initialise(Buffer.alloc(0))
+
+  const message = initiator.send()
+  responder.recv(message)
+
+  const reply = responder.send()
+  initiator.recv(reply)
+
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
+  t.end()
+})


### PR DESCRIPTION
Hi y'all. We're planning to use Noise for our upcoming [Cabal](https://github.com/cabal-club/cable) work, and we'd like to build on top of the lovely work y'all have already done here.

This PR adds support for the `NN` and `NNpsk0` handshake patterns. `psk0` is the only pre-shared key position that I've explicitly tested against.

I've tested this PR against [some Rust code](https://codeberg.org/kira/rust-NoiseNNPsk0) that uses [snow](https://crates.io/crates/snow), a Rust implementation of Noise, and am happy to report that they are able to exchange encrypted transport messages.

One interesting oddity was that [in my Node.js code](https://github.com/hackergrrl/noise-handshake/blob/NNpsk0-ex/ex.js) I had to do the opposite of what the `README.md` here suggests to get interop working, which meant doing `const send = new Cipher(initiator.tx)` instead of `const send = new Cipher(initiator.rx)` as the `README.md` here says.

Thanks! 🦊 