### PR TITLE
Throw if maximum Noise message length is exceeded

### DIFF
--- a/cipher.js
+++ b/cipher.js
@@ -22,6 +22,7 @@ module.exports = class CipherState {
     if (!ad) ad = b4a.alloc(0)
 
     const ciphertext = encryptWithAD(this.key, this.nonce, ad, plaintext)
+    if (ciphertext.length > 65535) throw new Error(`ciphertext length of ${ciphertext.length} exceeds maximum Noise message length of 65535`)
     this.nonce++
 
     return ciphertext
@@ -30,6 +31,7 @@ module.exports = class CipherState {
   decrypt (ciphertext, ad) {
     if (!this.hasKey) return ciphertext
     if (!ad) ad = b4a.alloc(0)
+    if (ciphertext.length > 65535) throw new Error(`ciphertext length of ${ciphertext.length} exceeds maximum Noise message length of 65535`)
 
     const plaintext = decryptWithAD(this.key, this.nonce, ad, ciphertext)
     this.nonce++

--- a/test/cipher.js
+++ b/test/cipher.js
@@ -82,6 +82,39 @@ test('identity with ad', function (assert) {
   assert.end()
 })
 
+test('max encrypt length', function (assert) {
+  assert.plan(2)
+
+  const key = Buffer.alloc(Cipher.KEYBYTES)
+  randombytes_buf(key)
+  const cipher = new Cipher(key)
+
+  const plaintext = Buffer.alloc(90_000).fill(0x08)
+
+  try {
+    cipher.encrypt(plaintext)
+  } catch (err) {
+    assert.ok(err instanceof Error)
+    assert.equals(err.message, 'ciphertext length of 90016 exceeds maximum Noise message length of 65535')
+  }
+})
+
+test('max decrypt length', function (assert) {
+  assert.plan(2)
+
+  const key = Buffer.alloc(Cipher.KEYBYTES)
+  randombytes_buf(key)
+  const cipher = new Cipher(key)
+
+  const ciphertext = Buffer.alloc(100_000).fill(0xBABECAFE)
+  try {
+    cipher.decrypt(ciphertext)
+  } catch (err) {
+    assert.ok(err instanceof Error)
+    assert.equals(err.message, 'ciphertext length of 100000 exceeds maximum Noise message length of 65535')
+  }
+})
+
 // test.skip('rekey', function (assert) {
 //   const key = Buffer.alloc(Cipher.KEYBYTES)
 //   const nonce = Buffer.alloc(Cipher.NONCEBYTES)


### PR DESCRIPTION
As per the Noise spec, Revision 34, Section 3: "All Noise messages are less than or equal to 65535 bytes in length."